### PR TITLE
Chinese translation

### DIFF
--- a/source/strings.c
+++ b/source/strings.c
@@ -28,6 +28,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("로딩중…"),
 		STR_RU("загрузка…"),
 		STR_ZH("加载中…"),
+		STR_TW("加載中…"),
 	},
 
 	[StrId_Directory] =
@@ -43,6 +44,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("디렉토리"),
 		STR_RU("каталог"),
 		STR_ZH("目录"),
+		STR_TW("資料夾"),
 	},
 
 	[StrId_DefaultLongTitle] =
@@ -58,6 +60,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("홈브류 애플리케이션"),
 		STR_RU("приложение хомебреw"),
 		STR_ZH("自制应用程序"),
+		STR_TW("自製程式"),
 	},
 
 	[StrId_DefaultPublisher] =
@@ -73,6 +76,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("작자미상"),
 		STR_RU("неизвестный автор"),
 		STR_ZH("未知作者"),
+		STR_TW("未知作者"),
 	},
 
 	[StrId_IOError] =
@@ -88,6 +92,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("I/O 에러"),
 		STR_RU("I/O-ошибка"),
 		STR_ZH("读写出错"),
+		STR_TW("讀寫錯誤"),
 	},
 
 	[StrId_CouldNotOpenFile] =
@@ -103,6 +108,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("파일을 열 수 없습니다:\n%s"),
 		STR_RU("Не могу открыть файл:\n%s"),
 		STR_ZH("无法打开文件:\n%s"),
+		STR_TW("開啓檔案失敗:\n%s"),
 	},
 
 	[StrId_NoAppsFound_Title] =
@@ -117,7 +123,8 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Geen toepassingen gevonden"),
 		STR_KO("애플리케이션을 찾을 수 없습니다"),
 		STR_RU("приложение не найдено"),
-		STR_ZH("找不到可执行的应用程序"),
+		STR_ZH("找不到可执行的自制程序"),
+		STR_TW("未能找到可執行的自製程式"),
 	},
 
 	[StrId_NoAppsFound_Msg] =
@@ -179,8 +186,13 @@ const char* const g_strings[StrId_Max][16] =
 		),
 		STR_ZH(
 			"内存卡找不到任何可执行的应用程序。\n"
-			"请在内存卡的根目录建立「/3ds」子目录，\n"
+			"请在内存卡的根目录建立「3ds」子目录，\n"
 			"并存放自制应用软件至该目录。"
+		),
+		STR_TW(
+			"記憶體找不到任何可執行的應用程式。\n"
+			"請在記憶體建立「3ds」資料夾，\n"
+			"然後儲存自製軟體到此處。"
 		),
 	},
 
@@ -253,6 +265,12 @@ const char* const g_strings[StrId_Max][16] =
 			"  \xEE\x80\x80 重启设备\n"
 			"  \xEE\x80\x81 取消操作"
 		),
+		STR_TW(
+			"無法回到 \xEE\x81\xB3HOME 選單。\n"
+			"您需要重新啓動您的 3DS 設備。\n\n"
+			"  \xEE\x80\x80 重啓設備\n"
+			"  \xEE\x80\x81 取消操作"
+		),
 	},
 
 	[StrId_ReturnToHome] =
@@ -323,6 +341,12 @@ const char* const g_strings[StrId_Max][16] =
 			"  \xEE\x80\x81 取消操作\n"
 			"  \xEE\x80\x82 重启设备"
 		),
+		STR_TW(
+			"您即將返回到 \xEE\x81\xB3HOME 選單。\n\n"
+			"  \xEE\x80\x80 確認返回\n"
+			"  \xEE\x80\x81 取消操作\n"
+			"  \xEE\x80\x82 重啓設備"
+		),
 	},
 
 	[StrId_TitleSelector] =
@@ -338,6 +362,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("타이틀 선택기"),
 		STR_RU("Селектор заголовков"),
 		STR_ZH("应用启动器"),
+		STR_TW("自製程式啓動器"),
 	},
 
 	[StrId_ErrorReadingTitleMetadata] =
@@ -356,6 +381,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("타이틀 메타데이터를 읽는데 실패하였습니다.\n%08lX%08lX@%d"),
 		STR_RU("Ошибка чтения метаданных заголовка\n.%08lX%08lX@%d"),
 		STR_ZH("读取软件相关信息时发生错误：\n%08lX%08lX@%d"),
+		STR_TW("讀取軟體相關數據時發生錯誤：\n%08lX%08lX@%d"),
 	},
 
 	[StrId_NoTitlesFound] =
@@ -371,6 +397,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("타이틀을 찾지 못하였습니다."),
 		STR_RU("Заголовки не обнаружены"),
 		STR_ZH("系统中找不到任何软件。"),
+		STR_TW("操作系统内找不到任何軟體。"),
 	},
 
 	[StrId_SelectTitle] =
@@ -428,6 +455,11 @@ const char* const g_strings[StrId_Max][16] =
 		STR_ZH(
 			"请选择一个目标软件。\n\n"
 			"  \xEE\x80\x80 确认\n"
+			"  \xEE\x80\x81 取消"
+		),
+		STR_TW(
+			"請選擇一個目標軟體。\n\n"
+			"  \xEE\x80\x80 確認\n"
 			"  \xEE\x80\x81 取消"
 		),
 	},
@@ -489,6 +521,11 @@ const char* const g_strings[StrId_Max][16] =
 			"无法在当前选中的软件中启动自制软件。\n"
 			"请使用其它的漏洞来启动「自制软件启动器」。"
 		),
+		STR_TW(
+			"您所利用漏洞開啓的「自製軟體啓動器」\n"
+			"無法在當前選中的軟體啓動自製軟件。\n"
+			"請利用其它漏洞來啓動「自製軟體啓動器」。"
+		),
 	},
 
 	[StrId_MissingTargetTitle] =
@@ -537,6 +574,10 @@ const char* const g_strings[StrId_Max][16] =
 			"系统内找不到该应用程序\n"
 			"所需求的软件。"
 		),
+		STR_TW(
+			"系統找不到該應用程式\n"
+			"所需求的軟體。"
+		),
 	},
 
 	[StrId_NetLoader] =
@@ -551,7 +592,8 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("3dslink netwerk lader"),
 		STR_KO("3dslink 넷로더"),
 		STR_RU("Загрузчик 3dslink"),
-		STR_ZH("3dslink NetLoader 模块"),
+		STR_ZH("3dslink 网络执行模块"),
+		STR_TW("3dslink 網路執行模組"),
 	},
 
 	[StrId_NetLoaderUnavailable] =
@@ -566,7 +608,8 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("De netwerk lader is niet beschikbaar."),
 		STR_KO("넷로더는 현재 사용이 불가능 합니다."),
 		STR_RU("Загрузчик в настоящее время недоступен."),
-		STR_ZH("无法启动 Netloader 模块。"),
+		STR_ZH("无法启动 3dslink 网络执行模块。"),
+		STR_TW("無法啓動 3dslink 網路執行模組。"),
 	},
 
 	[StrId_NetLoaderError] =
@@ -582,6 +625,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_KO("에러가 발생했습니다.\n상세: [%s:%d]"),
 		STR_RU("Произошла ошибка.\nТехнические подробности: [%s:%d]"),
 		STR_ZH("发生错误。\n详细错误信息：[%s:%d]"),
+		STR_TW("發生錯誤。\n詳細錯誤資訊：[%s:%d]"),
 	},
 
 	[StrId_NetLoaderActive] =
@@ -641,6 +685,11 @@ const char* const g_strings[StrId_Max][16] =
 			"IP 地址：%lu.%lu.%lu.%lu，端口：%d\n\n"
 			"  \xEE\x80\x81 取消等待"
 		),
+		STR_TW(
+			"等待 3dslink 連接…\n"
+			"IP 位址：%lu.%lu.%lu.%lu，連接埠：%d\n\n"
+			"  \xEE\x80\x81 取消等待"
+		),
 	},
 
 	[StrId_NetLoaderTransferring] =
@@ -687,6 +736,10 @@ const char* const g_strings[StrId_Max][16] =
 		),
 		STR_ZH(
 			"正在传输…\n"
+			"已完成 %zu / %zu KiB"
+		),
+		STR_TW(
+			"正在傳輸…\n"
 			"已完成 %zu / %zu KiB"
 		),
 	},

--- a/source/strings.c
+++ b/source/strings.c
@@ -260,13 +260,13 @@ const char* const g_strings[StrId_Max][16] =
 			"  \xEE\x80\x81 Отмена"
 		),
 		STR_ZH(
-			"无法返回至系统的 \xEE\x81\xB3HOME 菜单。\n"
+			"无法返回至主机的 \xEE\x81\xB3HOME 菜单。\n"
 			"您需要重新启动您的 3DS 设备。\n\n"
 			"  \xEE\x80\x80 重启设备\n"
 			"  \xEE\x80\x81 取消操作"
 		),
 		STR_TW(
-			"無法回到 \xEE\x81\xB3HOME 選單。\n"
+			"無法返回至主機的 \xEE\x81\xB3HOME 選單。\n"
 			"您需要重新啓動您的 3DS 設備。\n\n"
 			"  \xEE\x80\x80 重啓設備\n"
 			"  \xEE\x80\x81 取消操作"
@@ -336,13 +336,13 @@ const char* const g_strings[StrId_Max][16] =
 			"  \xEE\x80\x82 Перезагрузите"
 		),
 		STR_ZH(
-			"您即将返回到系统的 \xEE\x81\xB3HOME 菜单。\n\n"
+			"您即将返回到主機的 \xEE\x81\xB3HOME 菜单。\n\n"
 			"  \xEE\x80\x80 确认返回\n"
 			"  \xEE\x80\x81 取消操作\n"
 			"  \xEE\x80\x82 重启设备"
 		),
 		STR_TW(
-			"您即將返回到 \xEE\x81\xB3HOME 選單。\n\n"
+			"您即將返回到主機的 \xEE\x81\xB3HOME 選單。\n\n"
 			"  \xEE\x80\x80 確認返回\n"
 			"  \xEE\x80\x81 取消操作\n"
 			"  \xEE\x80\x82 重啓設備"
@@ -396,8 +396,8 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Geen titels gevonden."),
 		STR_KO("타이틀을 찾지 못하였습니다."),
 		STR_RU("Заголовки не обнаружены"),
-		STR_ZH("系统中找不到任何软件。"),
-		STR_TW("操作系统内找不到任何軟體。"),
+		STR_ZH("主机内找不到任何软件。"),
+		STR_TW("主機内找不到任何軟體。"),
 	},
 
 	[StrId_SelectTitle] =
@@ -571,11 +571,11 @@ const char* const g_strings[StrId_Max][16] =
 			"которая не установлена."
 		),
 		STR_ZH(
-			"系统内找不到该应用程序\n"
+			"主机找不到该应用程序\n"
 			"所需求的软件。"
 		),
 		STR_TW(
-			"系統找不到該應用程式\n"
+			"主機找不到該應用程式\n"
 			"所需求的軟體。"
 		),
 	},

--- a/source/strings.c
+++ b/source/strings.c
@@ -27,6 +27,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Laden…"),
 		STR_KO("로딩중…"),
 		STR_RU("загрузка…"),
+		STR_ZH("加载中…"),
 	},
 
 	[StrId_Directory] =
@@ -41,6 +42,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Map"),
 		STR_KO("디렉토리"),
 		STR_RU("каталог"),
+		STR_ZH("目录"),
 	},
 
 	[StrId_DefaultLongTitle] =
@@ -55,6 +57,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Homebrew toepassing"),
 		STR_KO("홈브류 애플리케이션"),
 		STR_RU("приложение хомебреw"),
+		STR_ZH("自制应用程序"),
 	},
 
 	[StrId_DefaultPublisher] =
@@ -69,6 +72,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Auteur onbekend"),
 		STR_KO("작자미상"),
 		STR_RU("неизвестный автор"),
+		STR_ZH("未知作者"),
 	},
 
 	[StrId_IOError] =
@@ -83,6 +87,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("I/O Fout"),
 		STR_KO("I/O 에러"),
 		STR_RU("I/O-ошибка"),
+		STR_ZH("读写出错"),
 	},
 
 	[StrId_CouldNotOpenFile] =
@@ -97,6 +102,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Kan bestand niet openen:\n%s"),
 		STR_KO("파일을 열 수 없습니다:\n%s"),
 		STR_RU("Не могу открыть файл:\n%s"),
+		STR_ZH("无法打开文件:\n%s"),
 	},
 
 	[StrId_NoAppsFound_Title] =
@@ -111,6 +117,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Geen toepassingen gevonden"),
 		STR_KO("애플리케이션을 찾을 수 없습니다"),
 		STR_RU("приложение не найдено"),
+		STR_ZH("找不到可执行的应用程序"),
 	},
 
 	[StrId_NoAppsFound_Msg] =
@@ -169,6 +176,11 @@ const char* const g_strings[StrId_Max][16] =
 			"На SD-карте нет приложений.\n"
 			"Убедитесь, что на карте SD есть каталог с\n"
 			"названием 3ds и она содержит приложения."
+		),
+		STR_ZH(
+			"内存卡找不到任何可执行的应用程序。\n"
+			"请在内存卡的根目录建立「/3ds」子目录，\n"
+			"并存放自制应用软件至该目录。"
 		),
 	},
 
@@ -234,7 +246,13 @@ const char* const g_strings[StrId_Max][16] =
 			"Вы собираетесь перезагрузить консоль.\n\n"
 			"  \xEE\x80\x80 Перезагрузите\n"
 			"  \xEE\x80\x81 Отмена"
-		)
+		),
+		STR_ZH(
+			"无法返回至系统的 \xEE\x81\xB3HOME 菜单。\n"
+			"您需要重新启动您的 3DS 设备。\n\n"
+			"  \xEE\x80\x80 重启设备\n"
+			"  \xEE\x80\x81 取消操作"
+		),
 	},
 
 	[StrId_ReturnToHome] =
@@ -299,6 +317,12 @@ const char* const g_strings[StrId_Max][16] =
 			"  \xEE\x80\x81 Отмена\n"
 			"  \xEE\x80\x82 Перезагрузите"
 		),
+		STR_ZH(
+			"您即将返回到系统的 \xEE\x81\xB3HOME 菜单。\n\n"
+			"  \xEE\x80\x80 确认返回\n"
+			"  \xEE\x80\x81 取消操作\n"
+			"  \xEE\x80\x82 重启设备"
+		),
 	},
 
 	[StrId_TitleSelector] =
@@ -313,6 +337,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Titel selector"),
 		STR_KO("타이틀 선택기"),
 		STR_RU("Селектор заголовков"),
+		STR_ZH("应用启动器"),
 	},
 
 	[StrId_ErrorReadingTitleMetadata] =
@@ -330,6 +355,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Fout bij het lezen van titel metadata.\n%08lX%08lX@%d"),
 		STR_KO("타이틀 메타데이터를 읽는데 실패하였습니다.\n%08lX%08lX@%d"),
 		STR_RU("Ошибка чтения метаданных заголовка\n.%08lX%08lX@%d"),
+		STR_ZH("读取软件相关信息时发生错误：\n%08lX%08lX@%d"),
 	},
 
 	[StrId_NoTitlesFound] =
@@ -344,6 +370,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Geen titels gevonden."),
 		STR_KO("타이틀을 찾지 못하였습니다."),
 		STR_RU("Заголовки не обнаружены"),
+		STR_ZH("系统中找不到任何软件。"),
 	},
 
 	[StrId_SelectTitle] =
@@ -397,6 +424,11 @@ const char* const g_strings[StrId_Max][16] =
 			"Выберите целевой заголовок.\n\n"
 			"  \xEE\x80\x80 Выберите\n"
 			"  \xEE\x80\x81 Отмена"
+		),
+		STR_ZH(
+			"请选择一个目标软件。\n\n"
+			"  \xEE\x80\x80 确认\n"
+			"  \xEE\x80\x81 取消"
 		),
 	},
 
@@ -452,6 +484,11 @@ const char* const g_strings[StrId_Max][16] =
 			"приложений под целевыми заголовками.\n"
 			"Пожалуйста, используйте другой эксплойт."
 		),
+		STR_ZH(
+			"您所利用漏洞启动的「自制软件启动器」，\n"
+			"无法在当前选中的软件中启动自制软件。\n"
+			"请使用其它的漏洞来启动「自制软件启动器」。"
+		),
 	},
 
 	[StrId_MissingTargetTitle] =
@@ -496,6 +533,10 @@ const char* const g_strings[StrId_Max][16] =
 			"Для приложения требуется зависимость,\n"
 			"которая не установлена."
 		),
+		STR_ZH(
+			"系统内找不到该应用程序\n"
+			"所需求的软件。"
+		),
 	},
 
 	[StrId_NetLoader] =
@@ -510,6 +551,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("3dslink netwerk lader"),
 		STR_KO("3dslink 넷로더"),
 		STR_RU("Загрузчик 3dslink"),
+		STR_ZH("3dslink NetLoader 模块"),
 	},
 
 	[StrId_NetLoaderUnavailable] =
@@ -524,6 +566,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("De netwerk lader is niet beschikbaar."),
 		STR_KO("넷로더는 현재 사용이 불가능 합니다."),
 		STR_RU("Загрузчик в настоящее время недоступен."),
+		STR_ZH("无法启动 Netloader 模块。"),
 	},
 
 	[StrId_NetLoaderError] =
@@ -538,6 +581,7 @@ const char* const g_strings[StrId_Max][16] =
 		STR_NL("Er is een fout opgetreden\nTechnische details: [%s:%d]"),
 		STR_KO("에러가 발생했습니다.\n상세: [%s:%d]"),
 		STR_RU("Произошла ошибка.\nТехнические подробности: [%s:%d]"),
+		STR_ZH("发生错误。\n详细错误信息：[%s:%d]"),
 	},
 
 	[StrId_NetLoaderActive] =
@@ -591,7 +635,12 @@ const char* const g_strings[StrId_Max][16] =
 			"Ожидание подключения 3dslink…\n"
 			"айпи адрес: %lu.%lu.%lu.%lu, Порт: %d\n\n"
 			"  \xEE\x80\x81 Отмена"
-		)
+		),
+		STR_ZH(
+			"等待 3dslink 连接…\n"
+			"IP 地址：%lu.%lu.%lu.%lu，端口：%d\n\n"
+			"  \xEE\x80\x81 取消等待"
+		),
 	},
 
 	[StrId_NetLoaderTransferring] =
@@ -635,6 +684,10 @@ const char* const g_strings[StrId_Max][16] =
 		STR_RU(
 			"Передача…\n"
 			"%zu из %zu КИБ написано"
+		),
+		STR_ZH(
+			"正在传输…\n"
+			"已完成 %zu / %zu KiB"
 		),
 	},
 };

--- a/source/text.c
+++ b/source/text.c
@@ -28,24 +28,26 @@ void textInit(void)
 
 	FILE* f = fopen("sdmc:/3ds/locale.bin", "rb");
 	if (f) {
-		u8 c;
-		if (fread(&c, sizeof(c), 1, f) == 1) {
-			// Support normal text editor
+		// File opened, read its content.
+		u8 c = 0xFF;
+		u8 readSuccess = fread(&c, sizeof(c), 1, f) == 1;
+		fclose(f);
+
+		if (readSuccess) {
+			// Allow user to edit this file without hex editor.
 			if (c >= '0' && c <= '9') {
-				c -= '0';
+				c = c - '0';
 			} else if (c >= 'a' && c <= 'z') {
 				c = c - 'a' + 0xa;
 			} else if (c >= 'A' && c <= 'Z') {
 				c = c - 'A' + 0xa;
 			}
 
-			s_textLang = c;
-		}
-		fclose(f);
-
-		// If the language id is invalid, fall back to system locale.
-		if (c >= 0 && c <= 11) {
-			return ;
+			// If the language id is valid, skip get system language.
+			if (c >= 0 && c <= 11) {
+				s_textLang = c;
+				return ;
+			}
 		}
 	}
 

--- a/source/text.c
+++ b/source/text.c
@@ -26,6 +26,16 @@ void textInit(void)
 		tex->lodParam = 0;
 	}
 
+	FILE* f = fopen("sdmc:/3ds/locale.bin", 'rb');
+	if (f) {
+		u8 c;
+		if (fread(&c, sizeof(c), 1, f) == 1) {
+			s_textLang = c;
+		}
+		fclose(f);
+		return ;
+	}
+
 	Result res = cfguInit();
 	if (R_SUCCEEDED(res))
 	{

--- a/source/text.c
+++ b/source/text.c
@@ -30,10 +30,23 @@ void textInit(void)
 	if (f) {
 		u8 c;
 		if (fread(&c, sizeof(c), 1, f) == 1) {
+			// Support normal text editor
+			if (c >= '0' && c <= '9') {
+				c -= '0';
+			} else if (c >= 'a' && c <= 'z') {
+				c = c - 'a' + 0xa;
+			} else if (c >= 'A' && c <= 'Z') {
+				c = c - 'A' + 0xa;
+			}
+
 			s_textLang = c;
 		}
 		fclose(f);
-		return ;
+
+		// If the language id is invalid, fall back to system locale.
+		if (c >= 0 && c <= 11) {
+			return ;
+		}
 	}
 
 	Result res = cfguInit();

--- a/source/text.c
+++ b/source/text.c
@@ -26,7 +26,7 @@ void textInit(void)
 		tex->lodParam = 0;
 	}
 
-	FILE* f = fopen("sdmc:/3ds/locale.bin", 'rb');
+	FILE* f = fopen("sdmc:/3ds/locale.bin", "rb");
 	if (f) {
 		u8 c;
 		if (fread(&c, sizeof(c), 1, f) == 1) {

--- a/source/text.c
+++ b/source/text.c
@@ -26,31 +26,6 @@ void textInit(void)
 		tex->lodParam = 0;
 	}
 
-	FILE* f = fopen("sdmc:/3ds/locale.bin", "rb");
-	if (f) {
-		// File opened, read its content.
-		u8 c = 0xFF;
-		u8 readSuccess = fread(&c, sizeof(c), 1, f) == 1;
-		fclose(f);
-
-		if (readSuccess) {
-			// Allow user to edit this file without hex editor.
-			if (c >= '0' && c <= '9') {
-				c = c - '0';
-			} else if (c >= 'a' && c <= 'z') {
-				c = c - 'a' + 0xa;
-			} else if (c >= 'A' && c <= 'Z') {
-				c = c - 'A' + 0xa;
-			}
-
-			// If the language id is valid, skip get system language.
-			if (c >= 0 && c <= 11) {
-				s_textLang = c;
-				return ;
-			}
-		}
-	}
-
 	Result res = cfguInit();
 	if (R_SUCCEEDED(res))
 	{


### PR DESCRIPTION
Commits:
* Added Chinese Translation
* ~~Force a locale by specifying a language id using `sdmc:/3ds/locale.bin`.~~

~~`locale.bin`: Value of ([CFG_Language](https://github.com/smealum/ctrulib/blob/master/libctru/include/3ds/services/cfgu.h#L20)) in ASCII hex (1 character long, 1 Byte) or the actual language id (1 Byte).~~

~~For example, to set the language to `CFG_LANGUAGE_TW`, you can open the file as notepad and type `B`, or fire a hex editor and fill in `0B`.~~

Know Issue:
* ~~Due to font missing some characters in EUR console (not sure about JPN or other regions), some of the characters will display as a question mark.~~