### PR TITLE
Add support for Rosalina title-selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ include $(DEVKITARM)/3ds_rules
 
 export VER_MAJOR	:= 2
 export VER_MINOR	:= 0
-export VER_PATCH	:= 0
+export VER_PATCH	:= 1
 
 export VERSTRING	:=	v$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
I sent a PR to Luma3DS to add Rosalina title-selection for backwards compatibility: https://github.com/AuroraWright/Luma3DS/pull/857

This, therefore, implements the use of that feature in hbmenu, and also increments the version number to 2.0.1.  