### PR TITLE
Hide hidden files

### DIFF
--- a/source/menu-list.c
+++ b/source/menu-list.c
@@ -106,9 +106,8 @@ int menuScan(const char* target)
 		FS_DirectoryEntry* entry = &dirSt->entry_data[dirSt->index];
 		menuEntry_s* me = NULL;
 		bool shortcut = false;
-		if (entry->attributes & FS_ATTRIBUTE_HIDDEN) {
+		if (entry->attributes & FS_ATTRIBUTE_HIDDEN) 
 			continue;
-		}
 
 		if (entry->attributes & FS_ATTRIBUTE_DIRECTORY)
 			me = menuCreateEntry(ENTRY_TYPE_FOLDER);

--- a/source/menu-list.c
+++ b/source/menu-list.c
@@ -106,6 +106,9 @@ int menuScan(const char* target)
 		FS_DirectoryEntry* entry = &dirSt->entry_data[dirSt->index];
 		menuEntry_s* me = NULL;
 		bool shortcut = false;
+		if (entry->attributes & FS_ATTRIBUTE_HIDDEN) {
+			continue;
+		}
 
 		if (entry->attributes & FS_ATTRIBUTE_DIRECTORY)
 			me = menuCreateEntry(ENTRY_TYPE_FOLDER);


### PR DESCRIPTION
Fairly simple change. I believe that mac hides the ._ files so it should fix that issue aswell. Also kinda resolves #11 cause you can just hide the folder on a PC and it wont show up.

I've tested with folders and apps and both are hidden and the unhidden apps still work nicely.