### PR TITLE
NetLoader improvements

### DIFF
--- a/source/language.c
+++ b/source/language.c
@@ -628,6 +628,11 @@ const char* const g_strings[StrId_Max][16] =
 		STR_TW("發生錯誤。\n詳細錯誤資訊：[%s:%d]"),
 	},
 
+	[StrId_NetLoaderOffline] =
+	{
+		STR_EN("Offline, waiting for network…\n\n\n  \xEE\x80\x81 Cancel"),
+	},
+
 	[StrId_NetLoaderActive] =
 	{
 		STR_EN(

--- a/source/language.h
+++ b/source/language.h
@@ -26,6 +26,7 @@ typedef enum
 
 	StrId_NetLoader,
 	StrId_NetLoaderUnavailable,
+	StrId_NetLoaderOffline,
 	StrId_NetLoaderError,
 	StrId_NetLoaderActive,
 	StrId_NetLoaderTransferring,

--- a/source/main.c
+++ b/source/main.c
@@ -52,6 +52,7 @@ int main()
 		drawingFrame();
 	}
 
+	netloaderExit();
 	launchExit();
 	workerExit();
 	textExit();

--- a/source/ui/netloader.c
+++ b/source/ui/netloader.c
@@ -390,6 +390,11 @@ void netloaderUpdate(void)
 		wantExit = true;
 }
 
+void netloaderExit(void)
+{
+	wantExit = true;
+}
+
 void netloaderDrawBot(void)
 {
 	drawingSetMode(DRAW_MODE_DRAWING);

--- a/source/ui/netloader.h
+++ b/source/ui/netloader.h
@@ -6,3 +6,4 @@
 void netloaderTask(void* arg);
 void netloaderUpdate(void);
 void netloaderDrawBot(void);
+void netloaderExit(void);


### PR DESCRIPTION
- fix #29 (hang when closing the app while the netloader is shown)
- when starting the netloader and the wifi is down, wait for it to come up

Note: adds one translatable string.