### PR TITLE
Correctly display N2DSXL home button location

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -37,7 +37,6 @@ int main()
 		svcBreak(USERBREAK_PANIC);
 
 	ptmuInit();
-	cfguInit();
 	uiInit();
 	drawingInit();
 	textInit();
@@ -62,7 +61,6 @@ int main()
 	textExit();
 	drawingExit();
 	romfsExit();
-	cfguExit();
 	ptmuExit();
 	return 0;
 }

--- a/source/main.c
+++ b/source/main.c
@@ -37,6 +37,7 @@ int main()
 		svcBreak(USERBREAK_PANIC);
 
 	ptmuInit();
+	cfguInit();
 	uiInit();
 	drawingInit();
 	textInit();
@@ -61,6 +62,7 @@ int main()
 	textExit();
 	drawingExit();
 	romfsExit();
+	cfguExit();
 	ptmuExit();
 	return 0;
 }

--- a/source/ui.c
+++ b/source/ui.c
@@ -3,6 +3,7 @@
 // Global variables
 touchPosition g_touchPos;
 circlePosition g_cstickPos;
+u8 g_systemModel;
 
 // Static variables
 static UIState s_stateStack[UI_STATE_STACK_DEPTH];
@@ -12,7 +13,13 @@ static bool s_shouldExit;
 
 void uiInit(void)
 {
-	// Nothing here?
+	Result res = cfguInit();
+	if (R_SUCCEEDED(res))
+	{
+		res = CFGU_GetSystemModel(&g_systemModel);
+		cfguExit();
+	}
+	if (R_FAILED(res)) g_systemModel = 0;
 }
 
 void uiEnterBusy(void)

--- a/source/ui.h
+++ b/source/ui.h
@@ -28,6 +28,8 @@ typedef struct
 extern touchPosition g_touchPos;
 extern circlePosition g_cstickPos;
 
+extern u8 g_systemModel;
+
 extern const uiStateInfo_s g_uiStateTable[UI_STATE_MAX];
 #define g_uiStateBg (&g_uiStateTable[UI_STATE_BACKGROUND])
 

--- a/source/ui/menu.c
+++ b/source/ui/menu.c
@@ -286,7 +286,10 @@ void menuDrawBot(void)
 		if (opac > 0.0f)
 		{
 			textSetColor((u32)(opac*0x100) << 24);
-			textDrawInBox("\xEE\x81\xB3\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);
+			u8 model;
+			CFGU_GetSystemModel(&model);
+			// Check for New 2DS XL
+			textDrawInBox((model == 5) ? "\n\uE01A \uE073" : "\uE073\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);
 		} else
 		{
 			showingHomeIcon = false;

--- a/source/ui/menu.c
+++ b/source/ui/menu.c
@@ -286,10 +286,21 @@ void menuDrawBot(void)
 		if (opac > 0.0f)
 		{
 			textSetColor((u32)(opac*0x100) << 24);
-			u8 model;
-			CFGU_GetSystemModel(&model);
+			static u8 model = 0xFF;
+			if (model == 0xFF)
+			{
+				Result res = cfguInit();
+				if (R_SUCCEEDED(res))
+					res = CFGU_GetSystemModel(&model);
+				if (R_FAILED(res))
+					model = 0;
+				cfguExit();
+			}
 			// Check for New 2DS XL
-			textDrawInBox((model == 5) ? "\n\uE01A \uE073" : "\uE073\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);
+			if (model == 5)
+				textDraw(0.0f, 200.0f, 1.0f, 1.0f, true, "\n\uE01A \uE073");
+			else
+				textDrawInBox("\uE073\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);
 		} else
 		{
 			showingHomeIcon = false;

--- a/source/ui/menu.c
+++ b/source/ui/menu.c
@@ -286,18 +286,8 @@ void menuDrawBot(void)
 		if (opac > 0.0f)
 		{
 			textSetColor((u32)(opac*0x100) << 24);
-			static u8 model = 0xFF;
-			if (model == 0xFF)
-			{
-				Result res = cfguInit();
-				if (R_SUCCEEDED(res))
-					res = CFGU_GetSystemModel(&model);
-				if (R_FAILED(res))
-					model = 0;
-				cfguExit();
-			}
 			// Check for New 2DS XL
-			if (model == 5)
+			if (g_systemModel == 5)
 				textDraw(0.0f, 200.0f, 1.0f, 1.0f, true, "\n\uE01A \uE073");
 			else
 				textDrawInBox("\uE073\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);

--- a/source/ui/menu.c
+++ b/source/ui/menu.c
@@ -288,9 +288,9 @@ void menuDrawBot(void)
 			textSetColor((u32)(opac*0x100) << 24);
 			// Check for New 2DS XL
 			if (g_systemModel == 5)
-				textDraw(0.0f, 200.0f, 1.0f, 1.0f, true, "\n\uE01A \uE073");
+				textDraw(0.0f, 200.0f, 1.0f, 1.0f, true, "\n\xEE\x80\x9A \xEE\x81\xB3");
 			else
-				textDrawInBox("\uE073\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);
+				textDrawInBox("\xEE\x81\xB3\n▼", 0, 1.0f, 1.0f, 200.0f, 0.0f, 320.0f);
 		} else
 		{
 			showingHomeIcon = false;


### PR DESCRIPTION
It seems like the 3DS system font doesn't have the following characters: ◀◁
I'm using U+E01A (Left Arrow) as shown [here](https://www.3dbrew.org/wiki/System_Font), and it looks like [this](https://i.imgur.com/u56Nn87.png) on a N2DSXL.
This fixes #22 