### PR TITLE
Ignore directory entries that start with a period

### DIFF
--- a/source/menu-list.c
+++ b/source/menu-list.c
@@ -106,7 +106,7 @@ int menuScan(const char* target)
 		FS_DirectoryEntry* entry = &dirSt->entry_data[dirSt->index];
 		menuEntry_s* me = NULL;
 		bool shortcut = false;
-		if (entry->attributes & FS_ATTRIBUTE_HIDDEN) 
+		if (entry->attributes & FS_ATTRIBUTE_HIDDEN || dp->d_name[0] == '.')
 			continue;
 
 		if (entry->attributes & FS_ATTRIBUTE_DIRECTORY)


### PR DESCRIPTION
POSIX systems usually hide these files, so they should be hidden here as
well. macOS especially can create a ton of dotfiles (`.DS_Store`, "`._`"
files) that can create useless entries.