### PR TITLE
Fixed starred function when used inside an empty folder.

### DIFF
--- a/source/ui/menu.c
+++ b/source/ui/menu.c
@@ -184,7 +184,7 @@ void menuUpdate(void)
 		if (me->type == ENTRY_TYPE_FILE)
 			workerSchedule(netsenderTask, me);
 	}
-	else if (selectPress)
+	else if (selectPress && menu->nEntries > 0)
 	{
 		int i;
 		menuEntry_s* me;


### PR DESCRIPTION
This fixes a crash that occurs by trying to star an application inside an empty folder.