### PR TITLE
Prioritize .3dsx files over folders in menu sorting

### DIFF
--- a/source/menu-list.c
+++ b/source/menu-list.c
@@ -81,7 +81,7 @@ static int menuEntryCmp(const void *p1, const void *p2)
 		return lhs->isStarred ? -1 : 1;
 	if(lhs->type == rhs->type)
 		return strcasecmp(lhs->name, rhs->name);
-	if(lhs->type == ENTRY_TYPE_FOLDER)
+	if(lhs->type != ENTRY_TYPE_FOLDER)
 		return -1;
 	return 1;
 }


### PR DESCRIPTION
This change deviates away from a de facto standard of putting the directories first, and showing the files second. This behavior can be observed in a variety of different programs, such as the ls utility or GodMode9; however, it does not work that well here.

In the real world, folders seem to be mostly used for application data and do not contain anything that can be launched. If the user puts in enough effort to organize apps in folders, however, I would imagine that the user would probably use the "Star" functionality if absolutely necessary and would most likely maintain the `3ds` folder "clean".