### PR TITLE
Add --tags to non-release VERSTRING in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export VER_PATCH	:= 2
 export VERSTRING	:=	v$(VER_MAJOR).$(VER_MINOR).$(VER_PATCH)
 
 ifeq ($(RELEASE),)
-	export VERSTRING	:=	$(VERSTRING)-$(shell git describe --dirty --always)
+	export VERSTRING	:=	$(VERSTRING)-$(shell git describe --tags --dirty --always)
 endif
 
 #---------------------------------------------------------------------------------


### PR DESCRIPTION
As you've possibly noticed from the latest release build, the version string is a somewhat confusing `2.4.2-v2.4.1-4-gc63d531`. This is pulled from a `git describe --dirty --always` in the Makefile. `git describe` will by default only check *annotated* tags. There's a [long explanation of this behavior on StackOverflow](https://stackoverflow.com/questions/57685432/make-git-show-the-correct-tag-on-branches-with-git-describe) for anybody who's interested.

The latest tag as of this PR is `v2.4.2` but the latest *annotated* tag is `v2.4.1`. As such, `git describe` is picking up the wrong tag when building non-release versions.

For reference, here's me just running `git describe` from terminal, with and without the `--tags` argument:
```
# git describe --tags
v2.4.2-1-gc63d531
# git describe
v2.4.1-4-gc63d531
```

Adding `--tags` to the Makefile allows the correct tag to be picked up, whether or not it's an annotated tag. An alternative to accepting this PR would be to exclusively use annotated tags in future, so that they are always picked up by `git describe`.