### PR TITLE
text.c: Improve the performance of text rendering

### DIFF
--- a/source/text.c
+++ b/source/text.c
@@ -1,8 +1,13 @@
 #include "text.h"
 
+#define NUM_ASCII_CHARS 128
+
 static C3D_Tex* s_glyphSheets;
 static float s_textScale;
 static int s_textLang = CFG_LANGUAGE_EN;
+static charWidthInfo_s* s_asciiCacheCharWidth[NUM_ASCII_CHARS];
+// @Note: Could use s_asciiCacheCharWidth to reimplement fontCalcGlyphPos, but it would cache slightly less computations.
+static fontGlyphPos_s s_asciiCacheGlyphPos[NUM_ASCII_CHARS];
 
 void textInit(void)
 {
@@ -26,6 +31,15 @@ void textInit(void)
 			| GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_EDGE) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_EDGE);
 		tex->border = 0;
 		tex->lodParam = 0;
+	}
+
+	// Cache up front the results of fontGetCharWidthInfo and fontCalcGlyphPos for ASCII characters, since these functions
+	// can potentially take a long time.
+	for (uint32_t i = 0; i < NUM_ASCII_CHARS; i++)
+	{
+		int glyphIdx = fontGlyphIndexFromCodePoint(NULL, i);
+		s_asciiCacheCharWidth[i] = fontGetCharWidthInfo(NULL, glyphIdx);
+		fontCalcGlyphPos(&s_asciiCacheGlyphPos[i], NULL, glyphIdx, GLYPH_POS_CALC_VTXCOORD, 1, 1);
 	}
 
 	Result res = cfguInit();
@@ -71,6 +85,55 @@ static inline float maxf(float a, float b)
 	return a > b ? a : b;
 }
 
+charWidthInfo_s *textGetCharWidthFromCodePoint(uint32_t code)
+{
+	charWidthInfo_s *result;
+
+	if (code < NUM_ASCII_CHARS)
+	{
+		result = s_asciiCacheCharWidth[code];
+	}
+	else
+	{
+		int glyphIdx = fontGlyphIndexFromCodePoint(NULL, code);
+		result = fontGetCharWidthInfo(NULL, glyphIdx);
+	}
+
+	return result;
+}
+
+fontGlyphPos_s textGetGlyphPosFromCodePoint(uint32_t code, uint32_t flags, float scaleX, float scaleY)
+{
+	fontGlyphPos_s result;
+
+	if (code < NUM_ASCII_CHARS)
+	{
+		result = s_asciiCacheGlyphPos[code];
+
+		if ((flags & GLYPH_POS_AT_BASELINE))
+		{
+			float baselineOffset    = fontGetSystemFont()->finf.tglp->baselinePos;
+			result.vtxcoord.top    -= baselineOffset;
+			result.vtxcoord.bottom -= baselineOffset;
+		}
+
+		result.xOffset         *= scaleX;
+		result.xAdvance        *= scaleX;
+		result.width           *= scaleX;
+		result.vtxcoord.left   *= scaleX;
+		result.vtxcoord.right  *= scaleX;
+		result.vtxcoord.top    *= scaleY;
+		result.vtxcoord.bottom *= scaleY;
+	}
+	else
+	{
+		int glyphIdx = fontGlyphIndexFromCodePoint(NULL, code);
+		fontCalcGlyphPos(&result, NULL, glyphIdx, flags, scaleX, scaleY);
+	}
+
+	return result;
+}
+
 float textCalcWidth(const char* text)
 {
 	float    width = 0.0f;
@@ -95,13 +158,32 @@ float textCalcWidth(const char* text)
 
 		if (code > 0)
 		{
-			int glyphIdx = fontGlyphIndexFromCodePoint(NULL, code);
-			charWidthInfo_s* cwi = fontGetCharWidthInfo(NULL, glyphIdx);
+			charWidthInfo_s* cwi = textGetCharWidthFromCodePoint(code);
 			width += cwi->charWidth;
 		}
 	} while (code > 0);
 	return s_textScale*maxf(width, maxWidth);
 }
+
+typedef struct SortedGlyph
+{
+	int indexBuf;
+	int indexSheet;
+	float x, y;
+} SortedGlyph;
+
+static int cmpGlyphSort(const void *p1, const void *p2)
+{
+	const SortedGlyph lhs = *(SortedGlyph*)p1;
+	const SortedGlyph rhs = *(SortedGlyph*)p2;
+
+	return lhs.indexSheet - rhs.indexSheet;
+}
+
+#define MAX_GLYPHS_PER_STRING 256
+static fontGlyphPos_s s_bufGlyph[MAX_GLYPHS_PER_STRING];
+static SortedGlyph    s_bufSort[MAX_GLYPHS_PER_STRING];
+static int 			      s_glyphCount;
 
 void textDraw(float x, float y, float scaleX, float scaleY, bool baseline, const char* text)
 {
@@ -113,6 +195,12 @@ void textDraw(float x, float y, float scaleX, float scaleY, bool baseline, const
 	u32 flags = GLYPH_POS_CALC_VTXCOORD | (baseline ? GLYPH_POS_AT_BASELINE : 0);
 	scaleX *= s_textScale;
 	scaleY *= s_textScale;
+
+	int vertexCount = 0;
+	C3D_Tex *sheetCur = NULL;
+
+	s_glyphCount = 0;
+
 	do
 	{
 		if (!*p) break;
@@ -127,22 +215,51 @@ void textDraw(float x, float y, float scaleX, float scaleY, bool baseline, const
 		}
 		else if (code > 0)
 		{
-			int glyphIdx = fontGlyphIndexFromCodePoint(NULL, code);
-			fontGlyphPos_s data;
-			fontCalcGlyphPos(&data, NULL, glyphIdx, flags, scaleX, scaleY);
-
-			// Draw the glyph
-			drawingSetTex(&s_glyphSheets[data.sheetIndex]);
-			drawingAddVertex(x+data.vtxcoord.left,  y+data.vtxcoord.bottom, data.texcoord.left,  data.texcoord.bottom);
-			drawingAddVertex(x+data.vtxcoord.right, y+data.vtxcoord.bottom, data.texcoord.right, data.texcoord.bottom);
-			drawingAddVertex(x+data.vtxcoord.left,  y+data.vtxcoord.top,    data.texcoord.left,  data.texcoord.top);
-			drawingAddVertex(x+data.vtxcoord.right, y+data.vtxcoord.top,    data.texcoord.right, data.texcoord.top);
-			drawingSubmitPrim(GPU_TRIANGLE_STRIP, 4);
-
-			x += data.xAdvance;
-
+			s_bufGlyph[s_glyphCount] = textGetGlyphPosFromCodePoint(code, flags, scaleX, scaleY);
+			s_bufSort[s_glyphCount]  = (SortedGlyph) { s_glyphCount, s_bufGlyph[s_glyphCount].sheetIndex, x, y };
+			x += s_bufGlyph[s_glyphCount].xAdvance;
+			s_glyphCount++;
 		}
-	} while (code > 0);
+	} while (code > 0 && s_glyphCount < MAX_GLYPHS_PER_STRING);  // If the string is too long, we'll truncate it.
+
+	// For performance reasons, we want to try to batch up as many glyphs per draw call as we can. To do this, all the
+	// glyphs must be in the same texture. But, the system font is split up into many textures that contain 5 glyphs
+	// each. If we were to batch glyphs naively, we'd typically swapping textures constantly within a piece of text, and
+	// that's devastating for performance. The best we can do is sort by glyph texture and batch that way.
+	qsort(s_bufSort, s_glyphCount, sizeof(s_bufSort[0]), cmpGlyphSort);
+
+	for (int i = 0; i < s_glyphCount; i++)
+	{
+		SortedGlyph     sorted     = s_bufSort[i];
+		fontGlyphPos_s *data       = &s_bufGlyph[sorted.indexBuf];
+		C3D_Tex        *sheetGlyph = &s_glyphSheets[sorted.indexSheet];
+		if (sheetCur != sheetGlyph)
+		{
+			if (vertexCount > 0)
+			{
+				drawingSubmitPrim(GPU_TRIANGLES, vertexCount);
+				vertexCount = 0;
+			}
+
+			sheetCur = sheetGlyph;
+			drawingSetTex(sheetCur);
+		}
+
+		// Draw the glyph
+		drawingAddVertex(sorted.x+data->vtxcoord.left,  sorted.y+data->vtxcoord.bottom, data->texcoord.left,  data->texcoord.bottom);
+		drawingAddVertex(sorted.x+data->vtxcoord.right, sorted.y+data->vtxcoord.bottom, data->texcoord.right, data->texcoord.bottom);
+		drawingAddVertex(sorted.x+data->vtxcoord.left,  sorted.y+data->vtxcoord.top,    data->texcoord.left,  data->texcoord.top);
+		drawingAddVertex(sorted.x+data->vtxcoord.left,  sorted.y+data->vtxcoord.top,    data->texcoord.left,  data->texcoord.top);
+		drawingAddVertex(sorted.x+data->vtxcoord.right, sorted.y+data->vtxcoord.bottom, data->texcoord.right, data->texcoord.bottom);
+		drawingAddVertex(sorted.x+data->vtxcoord.right, sorted.y+data->vtxcoord.top,    data->texcoord.right, data->texcoord.top);
+
+		vertexCount += 6;
+	}
+
+	if (vertexCount > 0)
+	{
+		drawingSubmitPrim(GPU_TRIANGLES, vertexCount);
+	}
 }
 
 void textDrawInBox(const char* text, int orientation, float scaleX, float scaleY, float baseline, float left, float right)

--- a/source/text.c
+++ b/source/text.c
@@ -1,12 +1,11 @@
 #include "text.h"
 
 #define NUM_ASCII_CHARS 128
-#define SHEETS_PER_BIG_SHEET 32
-
 static C3D_Tex* s_glyphSheets;
 static float s_textScale;
 static int s_textLang = CFG_LANGUAGE_EN;
 static uint32_t s_numFontSheetsCombined;
+static uint32_t s_sheetsPerBigSheet;
 static charWidthInfo_s* s_asciiCacheCharWidth[NUM_ASCII_CHARS];
 // @Note: Could use s_asciiCacheCharWidth to reimplement fontCalcGlyphPos, but it would cache slightly less computations.
 static fontGlyphPos_s s_asciiCacheGlyphPos[NUM_ASCII_CHARS];
@@ -19,16 +18,16 @@ static fontGlyphPos_s _textGetGlyphPosFromCodePoint(uint32_t code, uint32_t flag
 
 	if (result.sheetIndex < s_numFontSheetsCombined)
 	{
-		uint32_t indexWithinBigSheet = result.sheetIndex % SHEETS_PER_BIG_SHEET;
-		result.sheetIndex /= SHEETS_PER_BIG_SHEET;
+		uint32_t indexWithinBigSheet = result.sheetIndex % s_sheetsPerBigSheet;
+		result.sheetIndex /= s_sheetsPerBigSheet;
 
 		// Readjust glyph UVs to account for being a part of the combined texture.
-		result.texcoord.top    = (result.texcoord.top    + (SHEETS_PER_BIG_SHEET - indexWithinBigSheet - 1)) / (float) SHEETS_PER_BIG_SHEET;
-		result.texcoord.bottom = (result.texcoord.bottom + (SHEETS_PER_BIG_SHEET - indexWithinBigSheet - 1)) / (float) SHEETS_PER_BIG_SHEET;
+		result.texcoord.top    = (result.texcoord.top    + (s_sheetsPerBigSheet - indexWithinBigSheet - 1)) / (float) s_sheetsPerBigSheet;
+		result.texcoord.bottom = (result.texcoord.bottom + (s_sheetsPerBigSheet - indexWithinBigSheet - 1)) / (float) s_sheetsPerBigSheet;
 	}
 	else
 	{
-		result.sheetIndex = result.sheetIndex - s_numFontSheetsCombined + s_numFontSheetsCombined / SHEETS_PER_BIG_SHEET;
+		result.sheetIndex = result.sheetIndex - s_numFontSheetsCombined + s_numFontSheetsCombined / s_sheetsPerBigSheet;
 	}
 
 	return result;
@@ -60,8 +59,11 @@ void textInit(void)
 	// reinterpet the memory to describe a smaller set of much taller textures if we'd like. If we choose the right size,
 	// we can get all of the ASCII glyphs under a single texture, which will massively improve performance by reducing
 	// texture swaps within a piece of all-English text down to 0! We don't need any extra linear allocating to do this!
-	uint32_t numSheetsBig   = glyphInfo->nSheets / SHEETS_PER_BIG_SHEET;
-	uint32_t numSheetsSmall = glyphInfo->nSheets % SHEETS_PER_BIG_SHEET;
+	// Let's combine as many sheets as it takes to get to a big sheet height of 1024, which is the maximum height a
+	// texture can have.
+	s_sheetsPerBigSheet     = 1024U / glyphInfo->sheetHeight;
+	uint32_t numSheetsBig   = glyphInfo->nSheets / s_sheetsPerBigSheet;
+	uint32_t numSheetsSmall = glyphInfo->nSheets % s_sheetsPerBigSheet;
 	uint32_t numSheetsTotal = numSheetsBig + numSheetsSmall;
 	s_numFontSheetsCombined = glyphInfo->nSheets - numSheetsSmall;
 
@@ -70,14 +72,14 @@ void textInit(void)
 	for (uint32_t i = 0; i < numSheetsBig; i++)
 	{
 		C3D_Tex* tex = &s_glyphSheets[i];
-		fillSheet(tex, fontGetGlyphSheetTex(font, i * SHEETS_PER_BIG_SHEET), glyphInfo);
-		tex->height = (uint16_t) (tex->height * SHEETS_PER_BIG_SHEET);
-		tex->size   = tex->size * SHEETS_PER_BIG_SHEET;
+		fillSheet(tex, fontGetGlyphSheetTex(font, i * s_sheetsPerBigSheet), glyphInfo);
+		tex->height = (uint16_t) (tex->height * s_sheetsPerBigSheet);
+		tex->size   = tex->size * s_sheetsPerBigSheet;
 	}
 
 	for (uint32_t i = 0; i < numSheetsSmall; i++)
 	{
-		fillSheet(&s_glyphSheets[numSheetsBig + i], fontGetGlyphSheetTex(font, numSheetsBig * SHEETS_PER_BIG_SHEET + i), glyphInfo);
+		fillSheet(&s_glyphSheets[numSheetsBig + i], fontGetGlyphSheetTex(font, numSheetsBig * s_sheetsPerBigSheet + i), glyphInfo);
 	}
 
 	// Cache up front the results of fontGetCharWidthInfo and fontCalcGlyphPos for ASCII characters, since these functions

--- a/source/text.c
+++ b/source/text.c
@@ -1,36 +1,83 @@
 #include "text.h"
 
 #define NUM_ASCII_CHARS 128
+#define SHEETS_PER_BIG_SHEET 32
 
 static C3D_Tex* s_glyphSheets;
 static float s_textScale;
 static int s_textLang = CFG_LANGUAGE_EN;
+static uint32_t s_numFontSheetsCombined;
 static charWidthInfo_s* s_asciiCacheCharWidth[NUM_ASCII_CHARS];
 // @Note: Could use s_asciiCacheCharWidth to reimplement fontCalcGlyphPos, but it would cache slightly less computations.
 static fontGlyphPos_s s_asciiCacheGlyphPos[NUM_ASCII_CHARS];
+
+static fontGlyphPos_s _textGetGlyphPosFromCodePoint(uint32_t code, uint32_t flags, float scaleX, float scaleY)
+{
+	fontGlyphPos_s result;
+	int glyphIdx = fontGlyphIndexFromCodePoint(NULL, code);
+	fontCalcGlyphPos(&result, NULL, glyphIdx, flags, scaleX, scaleY);
+
+	if (result.sheetIndex < s_numFontSheetsCombined)
+	{
+		uint32_t indexWithinBigSheet = result.sheetIndex % SHEETS_PER_BIG_SHEET;
+		result.sheetIndex /= SHEETS_PER_BIG_SHEET;
+
+		// Readjust glyph UVs to account for being a part of the combined texture.
+		result.texcoord.top    = (result.texcoord.top    + (SHEETS_PER_BIG_SHEET - indexWithinBigSheet - 1)) / (float) SHEETS_PER_BIG_SHEET;
+		result.texcoord.bottom = (result.texcoord.bottom + (SHEETS_PER_BIG_SHEET - indexWithinBigSheet - 1)) / (float) SHEETS_PER_BIG_SHEET;
+	}
+	else
+	{
+		result.sheetIndex = result.sheetIndex - s_numFontSheetsCombined + s_numFontSheetsCombined / SHEETS_PER_BIG_SHEET;
+	}
+
+	return result;
+}
+
+static void fillSheet(C3D_Tex *tex, void *data, TGLP_s *glyphInfo)
+{
+	tex->data     = data;
+	tex->fmt      = glyphInfo->sheetFmt;
+	tex->size     = glyphInfo->sheetSize;
+	tex->width    = glyphInfo->sheetWidth;
+	tex->height   = glyphInfo->sheetHeight;
+	tex->param    = GPU_TEXTURE_MAG_FILTER(GPU_LINEAR) | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
+		| GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_EDGE) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_EDGE);
+	tex->border   = 0;
+	tex->lodParam = 0;
+}
 
 void textInit(void)
 {
 	// Ensure the shared system font is mapped
 	fontEnsureMapped();
 
+	CFNT_s* font = fontGetSystemFont();
 	// Load the glyph texture sheets
-	int i;
 	TGLP_s* glyphInfo = fontGetGlyphInfo(NULL);
-	s_glyphSheets = malloc(sizeof(C3D_Tex)*glyphInfo->nSheets);
+
+	// The way TGLP_s is set up, all of a font's texture sheets are adjacent in memory and have the same size. We can
+	// reinterpet the memory to describe a smaller set of much taller textures if we'd like. If we choose the right size,
+	// we can get all of the ASCII glyphs under a single texture, which will massively improve performance by reducing
+	// texture swaps within a piece of all-English text down to 0! We don't need any extra linear allocating to do this!
+	uint32_t numSheetsBig   = glyphInfo->nSheets / SHEETS_PER_BIG_SHEET;
+	uint32_t numSheetsSmall = glyphInfo->nSheets % SHEETS_PER_BIG_SHEET;
+	uint32_t numSheetsTotal = numSheetsBig + numSheetsSmall;
+	s_numFontSheetsCombined = glyphInfo->nSheets - numSheetsSmall;
+
+	s_glyphSheets = malloc(sizeof(C3D_Tex)*numSheetsTotal);
 	s_textScale = 30.0f / glyphInfo->cellHeight;
-	for (i = 0; i < glyphInfo->nSheets; i ++)
+	for (uint32_t i = 0; i < numSheetsBig; i++)
 	{
 		C3D_Tex* tex = &s_glyphSheets[i];
-		tex->data = fontGetGlyphSheetTex(NULL, i);
-		tex->fmt = glyphInfo->sheetFmt;
-		tex->size = glyphInfo->sheetSize;
-		tex->width = glyphInfo->sheetWidth;
-		tex->height = glyphInfo->sheetHeight;
-		tex->param = GPU_TEXTURE_MAG_FILTER(GPU_LINEAR) | GPU_TEXTURE_MIN_FILTER(GPU_LINEAR)
-			| GPU_TEXTURE_WRAP_S(GPU_CLAMP_TO_EDGE) | GPU_TEXTURE_WRAP_T(GPU_CLAMP_TO_EDGE);
-		tex->border = 0;
-		tex->lodParam = 0;
+		fillSheet(tex, fontGetGlyphSheetTex(font, i * SHEETS_PER_BIG_SHEET), glyphInfo);
+		tex->height = (uint16_t) (tex->height * SHEETS_PER_BIG_SHEET);
+		tex->size   = tex->size * SHEETS_PER_BIG_SHEET;
+	}
+
+	for (uint32_t i = 0; i < numSheetsSmall; i++)
+	{
+		fillSheet(&s_glyphSheets[numSheetsBig + i], fontGetGlyphSheetTex(font, numSheetsBig * SHEETS_PER_BIG_SHEET + i), glyphInfo);
 	}
 
 	// Cache up front the results of fontGetCharWidthInfo and fontCalcGlyphPos for ASCII characters, since these functions
@@ -39,7 +86,7 @@ void textInit(void)
 	{
 		int glyphIdx = fontGlyphIndexFromCodePoint(NULL, i);
 		s_asciiCacheCharWidth[i] = fontGetCharWidthInfo(NULL, glyphIdx);
-		fontCalcGlyphPos(&s_asciiCacheGlyphPos[i], NULL, glyphIdx, GLYPH_POS_CALC_VTXCOORD, 1, 1);
+		s_asciiCacheGlyphPos[i]  = _textGetGlyphPosFromCodePoint(i, GLYPH_POS_CALC_VTXCOORD, 1, 1);
 	}
 
 	Result res = cfguInit();
@@ -104,11 +151,9 @@ charWidthInfo_s *textGetCharWidthFromCodePoint(uint32_t code)
 
 fontGlyphPos_s textGetGlyphPosFromCodePoint(uint32_t code, uint32_t flags, float scaleX, float scaleY)
 {
-	fontGlyphPos_s result;
-
 	if (code < NUM_ASCII_CHARS)
 	{
-		result = s_asciiCacheGlyphPos[code];
+		fontGlyphPos_s result = s_asciiCacheGlyphPos[code];
 
 		if ((flags & GLYPH_POS_AT_BASELINE))
 		{
@@ -124,14 +169,12 @@ fontGlyphPos_s textGetGlyphPosFromCodePoint(uint32_t code, uint32_t flags, float
 		result.vtxcoord.right  *= scaleX;
 		result.vtxcoord.top    *= scaleY;
 		result.vtxcoord.bottom *= scaleY;
+		return result;
 	}
 	else
 	{
-		int glyphIdx = fontGlyphIndexFromCodePoint(NULL, code);
-		fontCalcGlyphPos(&result, NULL, glyphIdx, flags, scaleX, scaleY);
+		return _textGetGlyphPosFromCodePoint(code, flags, scaleX, scaleY);
 	}
-
-	return result;
 }
 
 float textCalcWidth(const char* text)


### PR DESCRIPTION
...by doing the following:

- Create caches around `fontGetCharWidthInfo` and `fontCalcGlyphPos` for ASCII characters, because those are pretty slow. (Non-English languages do not get this benefit - perhaps an LRU cache for non-ASCII glyphs could be made to help here.)
- Instead of doing one draw call per glyph, try to batch them as much as possible.
- Because the system font is so fragmented (5 glyphs per texture), this requires collecting glyphs and sorting them before drawing batches to avoid costly texture swaps. (citro2d has the function `C2D_TextOptimize` for this exact reason.)

This lets me maintain 60 FPS on my o3DS with the 3D turned on in most but not all circumstances. Enough glyphs on screen can still cause dropped frames.

UPDATE: One more commit from another breakthrough:

As it turns out, the system font texture sheets are all 128x32 pixels and adjacent in memory! We can reinterpet the memory starting at sheet 0 and describe a much bigger texture that encompasses all of the ASCII glyphs and make our cache use that instead of the individual sheets. This will massively improve performance by reducing texture swaps within a piece of text, down to 0 if it's all English. We don't need any extra linear allocating to do this!

The coalescing will be applied to all characters / glyph sheets up until the last `glyphInfo.nSheets % 32` sheets. This means that there are more operations per glyph being done in `textGetGlyphPosFromCodePoint`, but this is probably offset by the savings from not switching textures as often. And, this won't matter for English text, which has these results cached.