### PR TITLE
Fix NS_RebootToTitle build error with latest libctru

### DIFF
--- a/source/ui/reboot.c
+++ b/source/ui/reboot.c
@@ -31,7 +31,7 @@ void rebootUpdate(void)
 				// Reboot the console.
 				rebooting = true;
 				drawingSetFade(-1.0/60);
-				NS_RebootToTitle(2, 0);
+				NS_RebootToTitle(2, 0, 0);
 				nsExit();
 				return;
 			}


### PR DESCRIPTION
Fixes #102 

libctru updated the `NS_RebootToTitle` signature to require a third
`appmemtype` argument.

This patch updates the call in [source/ui/reboot.c](https://github.com/devkitPro/3ds-hbmenu/blob/master/source/ui/reboot.c#L34) to:

    NS_RebootToTitle(2, 0, 0);

Tested on:
- Arch Linux (LTS kernel)
- Latest devkitPro toolchain